### PR TITLE
github_token fix

### DIFF
--- a/.github/workflows/error_action.yml
+++ b/.github/workflows/error_action.yml
@@ -11,5 +11,6 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}} # Set the environment variable to the secret
         with:
           fetch-depth: 0


### PR DESCRIPTION
I'm *pretty* sure this will work. It pulls the token generated by gh and sets it as an environment variable to be picked up by gradle